### PR TITLE
Extractwhen to change to next question logic to a new method `shouldChangeToNextQuestion`

### DIFF
--- a/Sources/ReccoHeadless/Entities/Question.swift
+++ b/Sources/ReccoHeadless/Entities/Question.swift
@@ -45,6 +45,8 @@ extension MultiChoiceQuestion {
 
 extension Question {
     public var isSingleChoice: Bool {
+        guard type == .multichoice else { return false }
+        
         switch value {
         case .numeric:
             return false

--- a/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
+++ b/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
@@ -124,7 +124,6 @@ class QuestionnaireViewModel: ObservableObject {
     /**
      Should change to the next question if the following conditions are met:
      - Question is a single choice question (multi choice with just 1 possible answer)
-     - Question is not numeric
      - Question is not the last question
      - Answer is not a multi choice
      - Answer is valid
@@ -135,7 +134,6 @@ class QuestionnaireViewModel: ObservableObject {
         isAnswerValid: Bool
     ) -> Bool {
         return question.isSingleChoice
-        && question.type != .numeric
         && !isOnLastQuestion
         && answer.multichoice != nil
         && isAnswerValid

--- a/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
+++ b/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
@@ -17,13 +17,13 @@ class QuestionnaireViewModel: ObservableObject {
     @Published var sendError: Error?
     @Published var sendLoading: Bool = false
     @Published var mainButtonEnabled: Bool
-    
+
     var currentIndex: Int {
         currentQuestion.flatMap {
             questions?.firstIndex(of: $0)
         } ?? 0
     }
-    
+
     var isOnLastQuestion: Bool {
         return currentIndex == (questions?.count ?? 0) - 1
     }
@@ -49,13 +49,13 @@ class QuestionnaireViewModel: ObservableObject {
             validateAnswerOnQuestionChange()
         }
     }
-    
+
     @MainActor
     func previousQuestion() {
         guard currentIndex != 0 else { return }
         currentQuestion = questions?[safe: currentIndex - 1]
     }
-    
+
     @MainActor
     func next() {
         if isOnLastQuestion {
@@ -66,7 +66,7 @@ class QuestionnaireViewModel: ObservableObject {
             currentQuestion = questions?[safe: currentIndex + 1]
         }
     }
-    
+
     @MainActor
     func answer(_ answer: EitherAnswerType, for question: Question) {
         let isValid = validate(
@@ -74,36 +74,25 @@ class QuestionnaireViewModel: ObservableObject {
             for: question,
             mandatoryAnswer: shouldValidateAllAnswersOnQuestionChange
         )
-        
+
         answers[question] = .init(
             value: answer,
             questionId: question.id,
             type: question.type,
             questionnaireId: question.questionnaireId
         )
-        
+
         if shouldValidateAllAnswersOnQuestionChange {
             mainButtonEnabled = validateAll(
                 until: question,
                 mandatoryAnswer: true
             )
+        } else {
+            mainButtonEnabled = isValid
         }
-        
-        if question.isSingleChoice,
-           answer.multichoice != nil,
-           question.type != .numeric,
-           !isOnLastQuestion,
-           isValid
-        {
+
+        if shouldChangeToNextQuestion(question: question, answer: answer, isAnswerValid: isValid) {
             next()
-        }
-        
-        if !shouldValidateAllAnswersOnQuestionChange {
-            mainButtonEnabled = validate(
-                answer: answer,
-                for: question,
-                mandatoryAnswer: false
-            )
         }
     }
 
@@ -125,13 +114,33 @@ class QuestionnaireViewModel: ObservableObject {
             initialLoadError = error
         }
     }
-    
+
     func dismiss() {
         nav.navigate(to: .dismiss)
     }
-    
+
     // MARK: Private methods
-    
+
+    /**
+     Should change to the next question if the following conditions are met:
+     - Question is a single choice question (multi choice with just 1 possible answer)
+     - Question is not numeric
+     - Question is not the last question
+     - Answer is not a multi choice
+     - Answer is valid
+     */
+    internal func shouldChangeToNextQuestion(
+        question: Question,
+        answer: EitherAnswerType,
+        isAnswerValid: Bool
+    ) -> Bool {
+        return question.isSingleChoice
+        && question.type != .numeric
+        && !isOnLastQuestion
+        && answer.multichoice != nil
+        && isAnswerValid
+    }
+
     private func validateAnswerOnQuestionChange() {
         $currentQuestion
             .compactMap { $0 }
@@ -144,7 +153,7 @@ class QuestionnaireViewModel: ObservableObject {
             }
             .assign(to: &$mainButtonEnabled)
     }
-    
+
     @MainActor
     private func sendQuestionnaire() async {
         sendLoading = true
@@ -160,13 +169,13 @@ class QuestionnaireViewModel: ObservableObject {
 
         sendLoading = false
     }
-    
+
     private func didAnswerAllQuestions() -> Bool {
         guard let lastQuestion = questions?.last else { return false }
 
         return validateAll(until: lastQuestion, mandatoryAnswer: true)
     }
-    
+
     internal func validate(
         answer: EitherAnswerType,
         for question: Question,
@@ -179,23 +188,23 @@ class QuestionnaireViewModel: ObservableObject {
                 return !mandatoryAnswer
             }
             return (q.minOptions...q.maxOptions).contains(count)
-            
+
         case let .numeric(q):
             guard q.minValue <= q.maxValue else { return false }
             guard let value = answer.numeric else {
                 return !mandatoryAnswer
             }
-            
+
             return (Double(q.minValue)...Double(q.maxValue)).contains(value)
         }
     }
-    
+
     internal func validateAll(until q: Question, mandatoryAnswer: Bool) -> Bool {
         guard let partial = questions?.firstIndex(of: q),
               let partialQuestions = questions?[0...partial] else {
             return false
         }
-        
+
         return partialQuestions.reduce(true) { partialResult, q in
             if let answer = answers[q]??.value {
                 return partialResult && validate(answer: answer, for: q, mandatoryAnswer: mandatoryAnswer)

--- a/Tests/ReccoUITests/Mocks/Mocks.swift
+++ b/Tests/ReccoUITests/Mocks/Mocks.swift
@@ -138,6 +138,22 @@ final class Mocks {
     static let multiChoiceCorrectAnswer = EitherAnswerType.multiChoice([1, 2])
     static let multiChoiceInvalidAnswer = EitherAnswerType.multiChoice([])
 
+    static let multiChoiceQuestions: [Question] = (0...4).map { index in
+        try! Question(
+            id: "question-\(index)",
+            questionnaireId: "questionnaire-\(index)",
+            index: index,
+            text: "Question \(index)",
+            type: .multichoice,
+            multiChoice: MultiChoiceQuestion(
+                maxOptions: 3,
+                minOptions: 1,
+                options: (1...5).map { MultiChoiceAnswerOption(id: $0, text: "\($0)") }
+            ),
+            multichoiceAnswer: [1, 2]
+        )
+    }
+
     static let numericQuestion: Question = try! Question(
         id: "question-0",
         questionnaireId: "questionnaire-0",

--- a/Tests/ReccoUITests/Questionnaire/QuestionnaireViewModelTest.swift
+++ b/Tests/ReccoUITests/Questionnaire/QuestionnaireViewModelTest.swift
@@ -346,6 +346,72 @@ final class QuestionnaireViewModelTest: XCTestCase {
         wait(for: [navigateExpectation], timeout: 1)
     }
 
+    // MARK: - shouldChangeToNextQuestion
+
+    func test_shouldChangeToNextQuestion_whenQuestionIsSingleChoiceAndAnswerIsValidAndIsNotLastQuestion_shouldReturnTrue() {
+        let questions = Mocks.singleChoiceQuestions
+        let currentQuestion = questions.first!
+        let viewModel = getViewModel()
+        viewModel.questions = questions
+        viewModel.currentQuestion = currentQuestion
+
+        let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.singleChoiceCorrectAnswer, isAnswerValid: true)
+
+        XCTAssertTrue(result)
+    }
+
+    func test_shouldChangeToNextQuestion_whenQuestionIsSingleChoiceAndAnswerIsValidAndIsLastQuestion_shouldReturnFalse() {
+        let questions = Mocks.singleChoiceQuestions
+        let currentQuestion = questions.last!
+        let viewModel = getViewModel()
+        viewModel.questions = questions
+        viewModel.currentQuestion = currentQuestion
+
+        let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.singleChoiceCorrectAnswer, isAnswerValid: true)
+
+
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldChangeToNextQuestion_whenQuestionIsSingleChoiceAndAnswerIsNotValidAndIsNotLastQuestion_shouldReturnFalse() {
+        let questions = Mocks.singleChoiceQuestions
+        let currentQuestion = questions.first!
+        let viewModel = getViewModel()
+        viewModel.questions = questions
+        viewModel.currentQuestion = currentQuestion
+
+        let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.singleChoiceCorrectAnswer, isAnswerValid: false)
+
+
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldChangeToNextQuestion_whenQuestionIsMultiChoiceAndAnswerIsValidAndIsNotLastQuestion_shouldReturnFalse() {
+        let questions = Mocks.multiChoiceQuestions
+        let currentQuestion = questions.first!
+        let viewModel = getViewModel()
+        viewModel.questions = questions
+        viewModel.currentQuestion = currentQuestion
+
+        let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.multiChoiceCorrectAnswer, isAnswerValid: true)
+
+
+        XCTAssertFalse(result)
+    }
+
+    func test_shouldChangeToNextQuestion_whenQuestionIsNumericAndAnswerIsValidAndIsNotLastQuestion_shouldReturnFalse() {
+        let questions = Mocks.numericQuestions
+        let currentQuestion = questions.first!
+        let viewModel = getViewModel()
+        viewModel.questions = questions
+        viewModel.currentQuestion = currentQuestion
+
+        let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.numericCorrectAnswer, isAnswerValid: true)
+
+
+        XCTAssertFalse(result)
+    }
+
     // MARK: - sendQuestionnaire
 
     func test_init_whenSendQuestionsFails_doesNotCallsNextScreenAndUpdatesError() async {


### PR DESCRIPTION
**Changes:**
- Extracted when to change to next question logic to a new method `shouldChangeToNextQuestion`
- Added tests for `shouldChangeToNextQuestion`
- Removed duplicated code computing if the answer is valid, it was being done twice when `shouldValidateAllAnswersOnQuestionChange` is `false`
- Moved question type check to isSingleChoice, to centralize that piece of logic
