### PR TITLE
Rename MeRepo to MeRepository

### DIFF
--- a/Sources/ReccoHeadless/Assembly.swift
+++ b/Sources/ReccoHeadless/Assembly.swift
@@ -43,8 +43,8 @@ public final class ReccoHeadlessAssembly: ReccoAssembly {
             LiveQuestionnaireRepository()
         }
         
-        container.register(type: MeRepo.self, singleton: true) { r in
-            LiveMeRepo(keychain: r.get())
+        container.register(type: MeRepository.self, singleton: true) { r in
+            LiveMeRepository(keychain: r.get())
         }
         
         container.register(type: Calendar.self) { _ in

--- a/Sources/ReccoHeadless/Repo/Repositories/MeRepository.swift
+++ b/Sources/ReccoHeadless/Repo/Repositories/MeRepository.swift
@@ -1,12 +1,12 @@
 import Foundation
 import Combine
 
-public protocol MeRepo {
+public protocol MeRepository {
     var currentUser: AnyPublisher<AppUser?, Never> { get }
     func getMe() async throws 
 }
 
-final class LiveMeRepo: MeRepo {
+final class LiveMeRepository: MeRepository {
     let keychain: KeychainProxy
     let _currentUser: CurrentValueSubject<AppUser?, Never>
     

--- a/Sources/ReccoUI/Onboarding/Outro/OnboardingOutroViewModel.swift
+++ b/Sources/ReccoUI/Onboarding/Outro/OnboardingOutroViewModel.swift
@@ -2,14 +2,14 @@ import Foundation
 import ReccoHeadless
 
 final class OnboardingOutroViewModel: ObservableObject {
-    private let meRepo: MeRepo
+    private let meRepo: MeRepository
     private let nav: ReccoCoordinator
     
     @Published var isLoading: Bool = false
     @Published var meError: Error?
 
     init(
-        meRepo: MeRepo,
+        meRepo: MeRepository,
         nav: ReccoCoordinator
     ) {
         self.meRepo = meRepo

--- a/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
@@ -4,12 +4,12 @@ import Combine
 
 final class SplashViewModel: ObservableObject {
     var cancellable: AnyCancellable?
-    private let repo: MeRepo
+    private let repo: MeRepository
     
     @Published var user: AppUser?
     
     init(
-        repo: MeRepo
+        repo: MeRepository
     ) {
         self.repo = repo
         bind()

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -37,7 +37,7 @@ public func login(userId: String) async throws {
     try await login(userId: userId, authRepository: get(), meRepository: get())
 }
 
-func login(userId: String, authRepository: AuthRepository, meRepository: MeRepo) async throws {
+func login(userId: String, authRepository: AuthRepository, meRepository: MeRepository) async throws {
     try await authRepository.login(clientUserId: userId)
     try await meRepository.getMe()
 }

--- a/Tests/ReccoUITests/Mocks/MockAssembly.swift
+++ b/Tests/ReccoUITests/Mocks/MockAssembly.swift
@@ -14,6 +14,6 @@ final class MockAssembly {
 
         // Register dependencies
         container.register(type: AuthRepository.self, service: { _ in mockAuthRepository })
-        container.register(type: MeRepo.self, service: { _ in mockMeRepository})
+        container.register(type: MeRepository.self, service: { _ in mockMeRepository})
     }
 }

--- a/Tests/ReccoUITests/Mocks/MockMeRepository.swift
+++ b/Tests/ReccoUITests/Mocks/MockMeRepository.swift
@@ -2,7 +2,7 @@ import XCTest
 import Combine
 @testable import ReccoHeadless
 
-final class MockMeRepository: MeRepo {
+final class MockMeRepository: MeRepository {
 
     enum ExpectationType {
         case getMe


### PR DESCRIPTION
This was the only Repository interface that was called Repo. Keeping things consistent