### PR TITLE
Throw SDK not initialized error when calling login or logout before initializing the sdk

### DIFF
--- a/Sources/ReccoHeadless/Core/di/ReccoContainer.swift
+++ b/Sources/ReccoHeadless/Core/di/ReccoContainer.swift
@@ -17,6 +17,14 @@ public func get<T>() -> T {
     ReccoSharedContainer.shared.resolve(type: T.self)!
 }
 
+public func tget<T>() throws -> T {
+    guard let result: T = ReccoSharedContainer.shared.resolve(type: T.self) else {
+        throw NSError(domain: "\(T.self) was not previously registered", code: 0)
+    }
+
+    return result
+}
+
 public func get<T, Arg1>(argument: Arg1) -> T {
     ReccoSharedContainer.shared.resolve(type: T.self, argument: argument)!
 }
@@ -95,6 +103,12 @@ extension ReccoSharedContainer: ReccoContainer {
         services[params] = { resolver, params in
             service(resolver, params[0] as! Arg1)
         }
+    }
+
+    func reset() {
+        services = [:]
+        singletons = [:]
+        rememberedSingletons = [:]
     }
 }
 

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -9,8 +9,8 @@ enum ReccoError: Error {
 /**
  Configures Recco SDK given a clientSecret and a style (optional)
  - Parameters:
- - clietSecret: Credential required to identify and authenticate the application.
- - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
+     - clietSecret: Credential required to identify and authenticate the application.
+     - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
  */
 public func initialize(
     clientSecret: String,
@@ -35,7 +35,7 @@ public func initialize(
 /**
  Performs login operation given a user identifier
  - Parameters:
- - userId: User to be consuming the SDK and to be creating its own experience.
+    - userId: User to be consuming the SDK and to be creating its own experience.
  */
 public func login(userId: String) async throws {
     do {

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -2,11 +2,15 @@ import Foundation
 import ReccoHeadless
 import SwiftUI
 
+enum ReccoError: Error {
+    case notInitialized
+}
+
 /**
  Configures Recco SDK given a clientSecret and a style (optional)
  - Parameters:
-    - clietSecret: Credential required to identify and authenticate the application.
-    - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
+ - clietSecret: Credential required to identify and authenticate the application.
+ - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
  */
 public func initialize(
     clientSecret: String,
@@ -31,25 +35,30 @@ public func initialize(
 /**
  Performs login operation given a user identifier
  - Parameters:
-    - userId: User to be consuming the SDK and to be creating its own experience.
+ - userId: User to be consuming the SDK and to be creating its own experience.
  */
 public func login(userId: String) async throws {
-    try await login(userId: userId, authRepository: get(), meRepository: get())
-}
-
-func login(userId: String, authRepository: AuthRepository, meRepository: MeRepository) async throws {
-    try await authRepository.login(clientUserId: userId)
-    try await meRepository.getMe()
+    do {
+        let authRepository: AuthRepository = try tget()
+        let meRepository: MeRepository = try tget()
+        try await authRepository.login(clientUserId: userId)
+        try await meRepository.getMe()
+    } catch {
+        throw ReccoError.notInitialized
+    }
 }
 
 /**
  Performs logout operation
  */
 public func logout() async throws {
-    let repo: AuthRepository = get()
-    try await repo.logout()
+    do {
+        let repo: AuthRepository = try tget()
+        try await repo.logout()
+    } catch {
+        throw ReccoError.notInitialized
+    }
 }
-
 
 /**
  Root UIViewController for Recco's full experience journey.

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -38,26 +38,30 @@ public func initialize(
     - userId: User to be consuming the SDK and to be creating its own experience.
  */
 public func login(userId: String) async throws {
+    let authRepository: AuthRepository
+    let meRepository: MeRepository
     do {
-        let authRepository: AuthRepository = try tget()
-        let meRepository: MeRepository = try tget()
-        try await authRepository.login(clientUserId: userId)
-        try await meRepository.getMe()
+        authRepository = try tget()
+        meRepository = try tget()
     } catch {
         throw ReccoError.notInitialized
     }
+
+    try await authRepository.login(clientUserId: userId)
+    try await meRepository.getMe()
 }
 
 /**
  Performs logout operation
  */
 public func logout() async throws {
+    let authRepository: AuthRepository
     do {
-        let repo: AuthRepository = try tget()
-        try await repo.logout()
+        authRepository = try tget()
     } catch {
         throw ReccoError.notInitialized
     }
+    try await authRepository.logout()
 }
 
 /**

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -9,8 +9,8 @@ enum ReccoError: Error {
 /**
  Configures Recco SDK given a clientSecret and a style (optional)
  - Parameters:
-     - clietSecret: Credential required to identify and authenticate the application.
-     - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
+    - clietSecret: Credential required to identify and authenticate the application.
+    - style: Provides the style configuration the application will use; the default is ReccoStyle.summer.
  */
 public func initialize(
     clientSecret: String,

--- a/Tests/ReccoUITests/Mocks/MockAssembly.swift
+++ b/Tests/ReccoUITests/Mocks/MockAssembly.swift
@@ -16,4 +16,8 @@ final class MockAssembly {
         container.register(type: AuthRepository.self, service: { _ in mockAuthRepository })
         container.register(type: MeRepository.self, service: { _ in mockMeRepository})
     }
+
+    static func reset() {
+        container.reset()
+    }
 }

--- a/Tests/ReccoUITests/PublicAPITest.swift
+++ b/Tests/ReccoUITests/PublicAPITest.swift
@@ -1,8 +1,28 @@
 import XCTest
+@testable import ReccoHeadless
 @testable import ReccoUI
 
 @MainActor
 final class PublicAPITest: XCTestCase {
+
+    // MARK: - initialize
+
+    func test_initialize_registersDependenciesAndInitializesAPI() throws {
+        MockAssembly.reset()
+        let clientSecret = "clientSecret"
+        let reccoStyle: ReccoStyle = .ocean
+
+        XCTAssertThrowsError(try tget() as AuthRepository)
+        XCTAssertThrowsError(try tget() as OnboardingViewModel)
+        ReccoUI.initialize(clientSecret: clientSecret, style: reccoStyle)
+
+        XCTAssertNoThrow(try tget() as AuthRepository)
+        XCTAssertNoThrow(try tget() as OnboardingViewModel)
+        XCTAssertEqual(BearerTokenHandler.clientSecret, "Bearer \(clientSecret)")
+        XCTAssertEqual(OpenAPIClientAPI.basePath, "http://api.sf-dev.significo.dev")
+        XCTAssertEqual(OpenAPIClientAPI.customHeaders["Accept-Language"], "en-US")
+        XCTAssertEqual(OpenAPIClientAPI.customHeaders["Client-Platform"], "iOS")
+    }
 
     // MARK: - login
     

--- a/Tests/ReccoUITests/PublicAPITest.swift
+++ b/Tests/ReccoUITests/PublicAPITest.swift
@@ -4,13 +4,21 @@ import XCTest
 @MainActor
 final class PublicAPITest: XCTestCase {
 
-    override class func setUp() {
-        MockAssembly.assemble()
+    // MARK: - login
+    
+    func test_login_whenCalledBeforeInitializeSDK_throwsError() async throws {
+        MockAssembly.reset()
+        do {
+            try await ReccoUI.login(userId: "userId")
+            XCTFail("Should have thrown an error")
+        } catch (let error) {
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error as? ReccoError, ReccoError.notInitialized)
+        }
     }
 
-    // MARK: - login
-
     func test_login_callsLoginAndGetMe() async throws {
+        MockAssembly.assemble()
         let mockAuthRepository = MockAssembly.mockAuthRepository
         let mockMeRepository = MockAssembly.mockMeRepository
         let userId = "userId"
@@ -27,7 +35,19 @@ final class PublicAPITest: XCTestCase {
 
     // MARK: - logout
 
+    func test_logout_whenCalledBeforeInitializeSDK_throwsError() async throws {
+        MockAssembly.reset()
+        do {
+            try await ReccoUI.logout()
+            XCTFail("Should have thrown an error")
+        } catch (let error) {
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error as? ReccoError, ReccoError.notInitialized)
+        }
+    }
+
     func test_logout_callsLogout() async throws {
+        MockAssembly.assemble()
         let mockAuthRepository = MockAssembly.mockAuthRepository
         let logoutExpectation = expectation(description: "login was not called")
         mockAuthRepository.expectations[.logout] = logoutExpectation


### PR DESCRIPTION
Changes
- Return error when login and logout methods are called before initializing the sdk
- Added tests to ensure initialized works correctly