### PR TITLE
[SHAD-370] Removed dashboard_screen AppUserMetric's category

### DIFF
--- a/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricCategoryDTO.swift
+++ b/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricCategoryDTO.swift
@@ -12,5 +12,4 @@ import AnyCodable
 
 internal enum AppUserMetricCategoryDTO: String, Codable, CaseIterable {
     case userSession = "user_session"
-    case dashboardScreen = "dashboard_screen"
 }

--- a/Sources/ReccoHeadless/Entities/AppUserMetricCategory.swift
+++ b/Sources/ReccoHeadless/Entities/AppUserMetricCategory.swift
@@ -2,5 +2,4 @@ import Foundation
 
 public enum AppUserMetricCategory: String, Codable, CaseIterable {
     case userSession = "user_session"
-    case dashboardScreen = "dashboard_screen"
 }

--- a/Sources/ReccoHeadless/Repo/mappers/MetricMapper.swift
+++ b/Sources/ReccoHeadless/Repo/mappers/MetricMapper.swift
@@ -37,8 +37,6 @@ extension AppUserMetricCategory {
         switch dto {
         case .userSession:
             self = .userSession
-        case .dashboardScreen:
-            self = .dashboardScreen
         }
     }
 }
@@ -75,8 +73,6 @@ extension AppUserMetricCategoryDTO {
         switch entity {
         case .userSession:
             self = .userSession
-        case .dashboardScreen:
-            self = .dashboardScreen
         }
     }
 }


### PR DESCRIPTION
## What

Ticket: https://vilua.atlassian.net/browse/SHAD-370
Android related Pr: https://github.com/SignificoHealth/recco-android-sdk/pull/83/files

## How

Removing the ocurrences of `dashboard_screen`'s `AppUserMetricCategrory` .

> Note: there is still an occurrence of `dashboard_screen` that can be found in the `sf-backend-open-api.json` Open Api Schema. also noticed here: https://github.com/SignificoHealth/recco-android-sdk/pull/83#pullrequestreview-1814229667
> We might update this PR or fix it separately.
